### PR TITLE
add libssl-dev to requirements for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cross-compiler. Cross-compiling from a x86-64 host is officially supported.
         sudo apt-get install cscope ctags libz-dev libexpat-dev \
           python language-pack-en texinfo \
           build-essential g++ git bison flex unzip \
-          libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc \
+          libssl-dev libxml-simple-perl libxml-sax-perl libxml2-dev libxml2-utils xsltproc \
           wget bc
 
 ### Dependencies for *64-bit* Fedora systems


### PR DESCRIPTION
Running op-build on Ubuntu 16.04 without having libssl-dev installed leads to the following error:

`scripts/sign-file.c:25:30: fatal error: openssl/opensslv.h: No such file or directory`

More verbose information:
```
[...]
tk@tpt:~/git/op-build$ time op-build
make: Entering directory '/home/tk/git/op-build/buildroot'
[...]
scripts/sign-file.c:25:30: fatal error: openssl/opensslv.h: No such file or directory
compilation terminated.
scripts/Makefile.host:107: recipe for target 'scripts/sign-file' failed
make[3]: *** [scripts/sign-file] Error 1
make[3]: *** Waiting for unfinished jobs....
  HOSTCC  scripts/dtc/srcpos.o
  HOSTCC  scripts/dtc/checks.o
  HOSTCC  scripts/mod/modpost.o
  HOSTCC  scripts/mod/file2alias.o
  HOSTCC  scripts/dtc/util.o
  SHIPPED scripts/dtc/dtc-lexer.lex.c
  SHIPPED scripts/dtc/dtc-parser.tab.h
  HOSTCC  scripts/dtc/dtc-lexer.lex.o
  SHIPPED scripts/dtc/dtc-parser.tab.c
  HOSTCC  scripts/dtc/dtc-parser.tab.o
  HOSTLD  scripts/dtc/dtc
  HOSTLD  scripts/mod/modpost
Makefile:560: recipe for target 'scripts' failed
make[2]: *** [scripts] Error 2
package/pkg-generic.mk:216: recipe for target '/home/tk/git/op-build/output/build/linux-4.10.7/.stamp_built' failed
make[1]: *** [/home/tk/git/op-build/output/build/linux-4.10.7/.stamp_built] Error 2
Makefile:79: recipe for target '_all' failed
make: *** [_all] Error 2
make: Leaving directory '/home/tk/git/op-build/buildroot'

real	44m55.881s
user	93m33.272s
sys	6m9.764s
tk@tpt:~/git/op-build$ 
```

This commit adds the libssl-dev package to the dependencies for Ubuntu/Debian systems.